### PR TITLE
Update umamba gha

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -32,20 +32,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Micromamba
-        uses: mamba-org/provision-with-micromamba@main
-        with:
-          environment-file: false
-
-      - name: Install conda environment
-        shell: bash -l {0}
-        run: |
-          micromamba create --file environment.yml   
+     - name: Setup Micromamba
+       uses: mamba-org/setup-micromamba@v1
+       init-shell: bash
+       with:
+         environment-file: environment.yml
           
       - name: Execute Notebook
         shell: bash -l {0}
         run: |
-          micromamba activate map-of-activities
           jupyter nbconvert --to notebook --execute map-of-activities.ipynb --output=map-of-activities-output.ipynb
           
       - name: Setup Pages

--- a/environment.yml
+++ b/environment.yml
@@ -2,10 +2,8 @@ name: map-of-activities
 channels:
   - conda-forge
 dependencies:
-  - python=3.10
-  - r
-  - jupyterlab
+  - python=3.11
   - jupyter
   - folium
-  - geopandas<0.13
+  - geopandas >=0.13.1
   - pyobis


### PR DESCRIPTION
Using [mamba-org/setup-micromamba](https://github.com/mamba-org/setup-micromamba) instead of the deprecated mamba-org/provision-with-micromamba.

@MathewBiddle this is the change we need to do in all repos that use the depreacted mamba-org/provision-with-micromamba. I'm tackling most of the IOOS stuff but I'm probably missing some key repos outside of the IOOS org.